### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "node bot.js"

--- a/README.md
+++ b/README.md
@@ -6,3 +6,4 @@ enhance gameplay by balancing current units, all while adding new ones.
 ## About the Author
 Skaarjlord is a balancer, not a modder. Most of the units used are not taken, but contributed from other authors on
 the steam workshop.
+[![Run on Repl.it](https://repl.it/badge/github/LemonsHQ/AEA)](https://repl.it/github/LemonsHQ/AEA)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@LemonsHQ/AEA-1).